### PR TITLE
set colors for Whitespace, LineNumbers and LineNumberCursor

### DIFF
--- a/colors/selenized-black.kak
+++ b/colors/selenized-black.kak
@@ -72,8 +72,12 @@ set-face global Information $br_yellow,$black
 set-face global Error $black,$br_red
 
 set-face global BufferPadding $black,$black
+set-face global Whitespace $white
 set-face global StatusLine $fg,$black
 set-face global StatusLineInfo $yellow,$black
+
+set-face global LineNumbers default
+set-face global LineNumberCursor default,default+r
 "
 
 }

--- a/colors/selenized-light.kak
+++ b/colors/selenized-light.kak
@@ -79,9 +79,12 @@ set-face global Information $yellow,$black
 set-face global Error $black,$red
 
 set-face global BufferPadding $black,$black
+set-face global Whitespace $br_black
 set-face global StatusLine $fg,$br_black
 set-face global StatusLineInfo $blue,$br_black
 
+set-face global LineNumbers default
+set-face global LineNumberCursor default,default+r
 "
 
 }


### PR DESCRIPTION
Hello

While trying your great themes, I experienced issue with "leaking" colors.

When I open kakoune, it is with dracula theme in my config, and so when I switch to selenized-light, undefined colors keep the old values.

This commit attempts to mitigate the most obvious problems.

Before

![image](https://user-images.githubusercontent.com/39315/68196668-341f2600-ffb9-11e9-9d97-b9f67339767f.png)

After

![image](https://user-images.githubusercontent.com/39315/68196685-3a150700-ffb9-11e9-8ed8-8f725dc7637e.png)
