### PR TITLE
add dark and white variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Port of [Selenized] color theme for [Kakoune] text editor.
 Ported variants:
 
 - [x] Selenized light
-- [ ] Selenized dark
+- [x] Selenized dark
 - [x] Selenized black
-- [ ] Selenized white
+- [x] Selenized white
 
 ## Screenshot
 

--- a/colors/selenized-dark.kak
+++ b/colors/selenized-dark.kak
@@ -1,0 +1,83 @@
+##################
+# SELENIZED DARK #
+##################
+# theme by Jan Warchoł
+# ported by Delapouite
+
+evaluate-commands %sh{
+
+bg="rgb:103c48"
+black="rgb:184956"
+br_black="rgb:2d5b69"
+white="rgb:72898f"
+fg="rgb:adbcbc"
+br_white="rgb:cad8d9"
+
+red="rgb:fa5750"
+green="rgb:75b938"
+yellow="rgb:dbb32d"
+blue="rgb:4695f7"
+magenta="rgb:f275be"
+cyan="rgb:41c7b9"
+orange="rgb:ed8649"
+violet="rgb:af88eb"
+
+br_red="rgb:ff665c"
+br_green="rgb:84c747"
+br_yellow="rgb:ebc13d"
+br_blue="rgb:58a3ff"
+br_magenta="rgb:ff84cd"
+br_cyan="rgb:53d6c7"
+br_orange="rgb:fd9456"
+br_violet="rgb:bd96fa"
+
+## code
+echo "
+set-face global value ${orange}+b
+set-face global type ${br_orange}
+set-face global variable ${magenta}
+set-face global module ${blue}
+set-face global function ${br_cyan}
+set-face global string ${br_green}
+set-face global keyword ${violet}+b
+set-face global operator ${br_cyan}
+set-face global attribute ${orange}
+set-face global comment ${white}
+set-face global meta ${br_orange}
+set-face global builtin ${fg}+b
+
+set-face global title ${blue}+u
+set-face global header ${br_cyan}+u
+set-face global bold ${br_white}+b
+set-face global italic ${br_white}+i
+set-face global mono ${br_green}
+set-face global block ${orange}
+set-face global link $blue
+set-face global bullet ${br_magenta}
+set-face global list ${magenta}
+
+set-face global Default ${fg},${bg}
+set-face global PrimarySelection $black,$white
+set-face global SecondarySelection ${fg},$br_black+i
+set-face global PrimaryCursor $bg,$red+b
+set-face global SecondaryCursor $black,$br_cyan+i
+set-face global MatchingChar $black,$blue
+set-face global Search $br_white,$green
+set-face global CurrentWord $white,$blue
+
+set-face global MenuForeground $cyan,$br_black+b
+set-face global MenuBackground $fg,$black
+
+set-face global Information $br_yellow,$black
+set-face global Error $black,$br_red
+
+set-face global BufferPadding $black,$black
+set-face global Whitespace $white
+set-face global StatusLine $fg,$black
+set-face global StatusLineInfo $yellow,$black
+
+set-face global LineNumbers default
+set-face global LineNumberCursor default,default+r
+"
+
+}

--- a/colors/selenized-white.kak
+++ b/colors/selenized-white.kak
@@ -1,0 +1,90 @@
+###################
+# SELENIZED WHITE #
+###################
+# theme by Jan Warchoł
+# ported by Delapouite
+
+evaluate-commands %sh{
+
+bg='rgb:ffffff'
+black='rgb:ebebeb'
+br_black='rgb:cdcdcd'
+white='rgb:878787'
+fg='rgb:474747'
+br_white='rgb:282828'
+
+red='rgb:d6000c'
+green='rgb:1d9700'
+yellow='rgb:c49700'
+blue='rgb:0064e4'
+magenta='rgb:dd0f9d'
+cyan='rgb:00ad9c'
+orange='rgb:d04a00'
+violet='rgb:7f51d6'
+
+br_red='rgb:bf0000'
+br_green='rgb:008400'
+br_yellow='rgb:af8500'
+br_blue='rgb:0054cf'
+br_magenta='rgb:c7008b'
+br_cyan='rgb:009a8a'
+br_orange='rgb:ba3700'
+br_violet='rgb:6b40c3'
+
+## code
+echo "
+set-face global value ${orange}+b
+set-face global type ${br_orange}
+set-face global variable ${magenta}
+set-face global module ${green}
+set-face global function ${br_cyan}
+set-face global string ${green}
+set-face global keyword ${violet}+b
+set-face global operator ${br_cyan}
+set-face global attribute ${orange}
+set-face global comment ${br_black}
+set-face global meta ${br_orange}
+set-face global builtin ${fg}+b
+"
+
+## markup
+echo "
+set-face global title ${blue}+u
+set-face global header ${br_cyan}
+set-face global bold ${br_orange}+b
+set-face global italic ${orange}+i
+set-face global mono ${green}
+set-face global block ${orange}
+set-face global link $blue
+set-face global bullet ${br_magenta}
+set-face global list ${magenta}
+"
+
+echo "
+set-face global Default ${br_white},${bg}
+set-face global PrimarySelection ${fg},$br_black+i
+set-face global SecondarySelection $black,$white
+set-face global PrimaryCursor $black,$red+b
+set-face global SecondaryCursor $bg,$br_cyan+i
+set-face global MatchingChar $black,$blue
+set-face global Search $br_white,$green
+set-face global CurrentWord $white,$blue
+
+# when item focused in menu
+set-face global MenuForeground $orange,$br_black+d
+# default bottom menu and autocomplete
+set-face global MenuBackground $fg,$black
+
+set-face global Information $yellow,$black
+set-face global Error $black,$red
+
+set-face global BufferPadding $black,$black
+set-face global Whitespace $br_black
+set-face global StatusLine $fg,$br_black
+set-face global StatusLineInfo $blue,$br_black
+
+set-face global LineNumbers default
+set-face global LineNumberCursor default,default+r
+"
+
+}


### PR DESCRIPTION
Hi

This commit add the 2 missing variants with colors values taken from this page:
https://github.com/jan-warchol/selenized/blob/master/the-values.md

It does not provide the screenshots: I let you do them so they can be the same as the 2 previous ones.